### PR TITLE
update deb package url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-SOURCE="https://wdl1.pcfg.cache.wpscdn.com/wpsdl/wpsoffice/download/linux/10920/wps-office_11.1.0.10920.XA_amd64.deb"
+SOURCE="https://wdl1.pcfg.cache.wpscdn.com/wpsdl/wpsoffice/download/linux/11664/wps-office_11.1.0.11664.XA_amd64.deb"
 DESTINATION="build.deb"
 OUTPUT="WPS-Office.AppImage"
 


### PR DESCRIPTION
The Debian package used to build this AppImage is somewhat old and needs to be fixed on newer distributions.

```
+ exec /tmp/.mount_WPS-OfTxCpnk/opt/application/wps
dlopen /tmp/.mount_WPS-OfTxCpnk/opt/application/libwpsmain.so failed , error: /tmp/.mount_WPS-OfTxCpnk/opt/application/libstdc++.so.6: version `GLIBCXX_3.4.30' not found (required by /lib/x86_64-linux-gnu/libicuuc.so.72)
```